### PR TITLE
Namespaced the notification class

### DIFF
--- a/lib/icon.js
+++ b/lib/icon.js
@@ -20,7 +20,7 @@ const icons = {
 
 const Icon = (type, height) => {
   const iconInfo = icons[type]
-  return `<svg class='notification__icon' height=${height || iconInfo[1]}
+  return `<svg class='notify-notification__icon' height=${height || iconInfo[1]}
   viewBox='0 0 ${iconInfo[0]} ${iconInfo[1]}' >${iconInfo[2]}</svg>`
 }
 export default Icon

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -25,18 +25,18 @@ class Notification {
     return container
   }
   open () {
-    window.requestAnimationFrame(() => this.notification.classList.add('notification--opened'), 0)
+    window.requestAnimationFrame(() => this.notification.classList.add('notify-notification--opened'), 0)
   }
   close () {
-    this.notification.classList.remove('notification--opened')
+    this.notification.classList.remove('notify-notification--opened')
     setTimeout(() => this.notification.parentNode.removeChild(this.notification), 500)
   }
   init () {
     this.getContainer()
     const notification = document.createElement('div')
-    notification.className = `notification notification--${this.type}`
-    notification.innerHTML = `<div class='notification__header'>${Icon(this.type)}</div>
-    <div class='notification__body'>${this.msg}</div>`
+    notification.className = `notify-notification notify-notification--${this.type}`
+    notification.innerHTML = `<div class='notify-notification__header'>${Icon(this.type)}</div>
+    <div class='notify-notification__body'>${this.msg}</div>`
 
     const container = this.getContainer()
     container.insertBefore(notification, container.firstChild)
@@ -60,4 +60,3 @@ const notify = (msg, type = defaultConfig.type, timeout = defaultConfig.timeout,
 }
 
 export default notify
-

--- a/lib/notify.styl
+++ b/lib/notify.styl
@@ -17,7 +17,7 @@
     right: 1em
 
 
-  .notification
+  .notify-notification
     color: #fff
     min-width: 160px
     max-width: 310px
@@ -36,7 +36,7 @@
       opacity: 1
       padding-top: 10px
       padding-bottom: 10px
-    
+
     &__body
       flex: 1
     &__icon


### PR DESCRIPTION
Consider name-spacing .notification with `notify`. Some CSS frameworks use the notification class and will clash with this library.